### PR TITLE
:chore: Change env example with host docker internal instead

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,5 @@ SMTP_SERVER_USERNAME=""
 SMTP_SERVER_PASSWORD=""
 WEBSITE_MAIL_RECIEVER="contact@321vegan.fr"
 ALTCHA_SECRET="a very long string to be used to generate an hmackey used by altcha captcha"
-BACKEND_API_URL="http://localhost:8000" # the 321vegan api uri
+BACKEND_API_URL="http://host.docker.internal:8000" # the 321vegan api uri
 BACKEND_API_KEY="" # the 321vegan api client key


### PR DESCRIPTION
We had issues with localhost not correctly calling the service in local. Replacing it with host.docker.internal fixes the issue